### PR TITLE
Update mercurial to 6.1.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      recipes_found: ${{ steps.recipes_changes.recipes_found }}
+      recipes_found: ${{ steps.recipes_changes.outputs.recipes_found }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/recipes/mercurial/meta.yaml
+++ b/recipes/mercurial/meta.yaml
@@ -1,3 +1,3 @@
 ---
 name: mercurial
-version: 6.1.1
+version: 6.1.2


### PR DESCRIPTION
to upload Python 3.10 wheels and fix file permissions on the S3 bucket.