### PR TITLE
Add pysam at version 0.19.1

### DIFF
--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -1,0 +1,3 @@
+---
+name: pysam
+version: 0.19.1


### PR DESCRIPTION
As of pysam-developers/pysam#1109 the upstream project is only building for `manylinux_2_24`, which is too new for EL7.