### PR TITLE
Add recipe for firecloud 0.16.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ specified with `purepy: true` in the recipe).
 
 At the end of the CI job, the wheels are uploaded to https://wheels.galaxyproject.org ,
 a Python Package Repository used by the [Galaxy Project](https://galaxyproject.org).
+
+Other options:
+- If an `env.sh` file is present in the same directory of the `meta.yaml` file,
+  it is sourced before building the wheel. This can be used e.g. to set the
+  `CIBW_` environment variables to configure cibuildwheel.
+- For a non-pure Python package: if `run_in_sdist` is set to `True` in
+  `meta.yaml` , then the sdist archive is extracted into a folder, and cibuildwheel
+  run inside it (instead of being passed the path of the sdist archive).
+- `run_in_sdist_before` can be defined in `meta.yaml` as a list of commands to
+  run in the folder where the sdist was extracted before the wheels are built.

--- a/recipes/firecloud/meta.yaml
+++ b/recipes/firecloud/meta.yaml
@@ -1,0 +1,9 @@
+---
+name: firecloud
+version: 0.16.38
+purepy: true
+run_in_sdist_before:
+  - |-
+    echo '[build-system]
+    requires = ["setuptools<80.3.0"]
+    build-backend = "setuptools.build_meta:__legacy__"' > pyproject.toml

--- a/wheel_builder.py
+++ b/wheel_builder.py
@@ -64,7 +64,6 @@ if __name__ == "__main__":
             commands.append(f". '{env_file}'")
 
         extracted_sdist_dir = None
-        package_path = sdist_filepath
         wheelhouse = os.path.join(os.getcwd(), "wheelhouse")
         if is_package_pure or run_in_sdist:
             tar_temp_dir = Path(tempfile.mkdtemp(dir=temp_dir))
@@ -77,7 +76,10 @@ if __name__ == "__main__":
             except ValueError:
                 raise Exception("Invalid sdist: didn't contain a single directory")
 
-            package_path = "."
+            if run_in_sdist_before:
+                commands.append(f"cd '{extracted_sdist_dir}'")
+                commands.extend(run_in_sdist_before)
+                commands.append("cd -")
 
         if is_package_pure:
             commands.append(f"python3 -m build --wheel --outdir '{wheelhouse}' '{extracted_sdist_dir}'")
@@ -86,7 +88,7 @@ if __name__ == "__main__":
             check_commands.append("cibuildwheel --print-build-identifiers")
             if run_in_sdist:
                 commands.append(f"cd '{extracted_sdist_dir}'")
-                commands.extend(run_in_sdist_before)
+            package_path = "." if run_in_sdist else sdist_filepath
             commands.append(f"cibuildwheel --output-dir '{wheelhouse}' '{package_path}'")
         joined_command = " && ".join(commands)
         joined_check_command = " && ".join(check_commands)


### PR DESCRIPTION
Also:
- Allow using `run_in_sdist_before` also for pure Python packages.
- Document `env.sh` files, and `run_in_sdist` and `run_in_sdist_before` options.